### PR TITLE
Change the default allocationSize and initialValue

### DIFF
--- a/src/main/java/org/jeduardo/entries/model/Entry.java
+++ b/src/main/java/org/jeduardo/entries/model/Entry.java
@@ -8,7 +8,7 @@ import javax.persistence.*;
 @Table(name = "entries")
 public class Entry {
     @Id
-    @SequenceGenerator(name="entries_id_seq", sequenceName="entries_id_seq")
+    @SequenceGenerator(name="entries_id_seq", sequenceName="entries_id_seq", allocationSize=1, initialValue=1)
     @GeneratedValue(generator="entries_id_seq")
     private int id = 0;
     private String content = null;


### PR DESCRIPTION
When running the application as multiple workers, the sequence
generator fails getting the right ids. It ends up having a race
condition because multiple workers are getting inconsistent
information about the available indexes sequence.

Both values have been set to 1.